### PR TITLE
feat: 实现请求指令帧和数据库格式定义

### DIFF
--- a/app/src/main/java/com/travellerse/cosray_app/MainActivity.kt
+++ b/app/src/main/java/com/travellerse/cosray_app/MainActivity.kt
@@ -1,13 +1,41 @@
 package com.travellerse.cosray_app
 
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.runtime.CompositionLocalProvider
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
+import androidx.compose.runtime.DisposableEffect
+import com.traveller.cosray_app.protocol.Protocol
 import com.travellerse.cosray_app.core.di.LocalAppContainer
 import com.travellerse.cosray_app.ui.CosRayApp
 import com.travellerse.cosray_app.ui.theme.CosRayAppTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
 
@@ -15,9 +43,31 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         val appContainer = (application as CosRayApplication).appContainer
+        val bleRepository = appContainer.bleRepository
         setContent {
             CompositionLocalProvider(LocalAppContainer provides appContainer) {
-                CosRayAppTheme { CosRayApp() }
+                CosRayAppTheme { 
+                    Column(
+                        modifier = Modifier.fillMaxSize(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        Button(
+                            onClick = {
+                                val commandFrame = Protocol.Command.buildRequestFrame()
+                                lifecycleScope.launch {
+                                    if (bleRepository.hasPermissions() && 
+                                        bleRepository.connectionState.value is DeviceConnectionState.Connected) {
+                                        bleRepository.sendCommand(commandFrame)
+                                    } else {
+                                    }
+                                }
+                            }
+                        ) {
+                            Text("Ask for Request")
+                        }
+                    CosRayApp() 
+                }
             }
         }
     }

--- a/app/src/main/java/com/travellerse/cosray_app/MainActivity.kt
+++ b/app/src/main/java/com/travellerse/cosray_app/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
         val bleRepository = appContainer.bleRepository
         setContent {
             CompositionLocalProvider(LocalAppContainer provides appContainer) {
-                CosRayAppTheme { 
+                CosRayAppTheme {
                     Column(
                         modifier = Modifier.fillMaxSize(),
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -56,7 +56,7 @@ class MainActivity : ComponentActivity() {
                             onClick = {
                                 val commandFrame = Protocol.Command.buildRequestFrame()
                                 lifecycleScope.launch {
-                                    if (bleRepository.hasPermissions() && 
+                                    if (bleRepository.hasPermissions() &&
                                         bleRepository.connectionState.value is DeviceConnectionState.Connected) {
                                         bleRepository.sendCommand(commandFrame)
                                     } else {
@@ -66,7 +66,7 @@ class MainActivity : ComponentActivity() {
                         ) {
                             Text("Ask for Request")
                         }
-                    CosRayApp() 
+                    CosRayApp()
                 }
             }
         }

--- a/app/src/main/java/com/travellerse/cosray_app/data/ble/BleRepository.kt
+++ b/app/src/main/java/com/travellerse/cosray_app/data/ble/BleRepository.kt
@@ -19,4 +19,5 @@ class BleRepository(private val controller: BleController) {
     fun connect(address: String) = controller.connect(address)
     fun disconnect() = controller.disconnect()
     fun hasPermissions(): Boolean = controller.hasBluetoothPermissions()
+    fun sendCommand(command: ByteArray) = controller.sendCommand(command)
 }

--- a/app/src/main/java/com/travellerse/cosray_app/protocol/Protocol.kt
+++ b/app/src/main/java/com/travellerse/cosray_app/protocol/Protocol.kt
@@ -11,7 +11,7 @@ object Protocol {
         const val FRAME_HEADER: Short = 0x55AA
         const val FRAME_TRAILER: Short = 0xAA55
 
-        const val CMD_TYPE_REQUEST_DATA: Byte = 0x01 
+        const val CMD_TYPE_REQUEST_DATA: Byte = 0x01
         const val CMD_ID_REQUEST_DATA: Byte = 0x01
 
         fun buildRequestFrame(cmdType: Byte = CMD_TYPE_REQUEST_DATA): ByteArray {
@@ -50,7 +50,7 @@ object Protocol {
         val pps: Int          // 上电以来PPS脉冲计数（4字节）
     ) {
         companion object {
-            const val SIZE = 14 
+            const val SIZE = 14
             fun fromByteBuffer(buffer: ByteBuffer): MuonData {
                 require(buffer.order() == ByteOrder.LITTLE_ENDIAN) { "MuonData 解析需小端序" }
                 return MuonData(
@@ -237,7 +237,7 @@ object Protocol {
                 val crc = buffer.short
                 val calculatedCrc = Command.calculateChecksum(
                     data = rawData,
-                    startIndex = 3, 
+                    startIndex = 3,
                     length = TOTAL_SIZE - 3 - 2 // 总长度 - 头部3字节 - CRC2字节 = 507
                 )
                 require((crc.toInt() and 0xFFFF) == (calculatedCrc.toInt() and 0xFFFF)) {

--- a/app/src/main/java/com/travellerse/cosray_app/protocol/Protocol.kt
+++ b/app/src/main/java/com/travellerse/cosray_app/protocol/Protocol.kt
@@ -1,0 +1,282 @@
+package com.traveller.cosray_app.protocol
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+object Protocol {
+
+    // 指令帧定义（App → ESP32）
+    object Command {
+        // 帧头/帧尾
+        const val FRAME_HEADER: Short = 0x55AA
+        const val FRAME_TRAILER: Short = 0xAA55
+
+        const val CMD_TYPE_REQUEST_DATA: Byte = 0x01 
+        const val CMD_ID_REQUEST_DATA: Byte = 0x01
+
+        fun buildRequestFrame(cmdType: Byte = CMD_TYPE_REQUEST_DATA): ByteArray {
+            val paramLength = 0 // 当前指令无参数，长度为0
+            // 总长度计算：帧头(2) + 指令类型(1) + 指令ID(1) + 预留参数长度(2) + 参数(0) + 校验和(1) + 帧尾(2)
+            val totalLength = 2 + 1 + 1 + 2 + paramLength + 1 + 2
+
+            val buffer = ByteBuffer.allocate(totalLength)
+                .order(ByteOrder.BIG_ENDIAN) // 指令帧默认大端序
+            buffer.putShort(FRAME_HEADER)
+            buffer.put(cmdType)
+            buffer.put(CMD_ID_REQUEST_DATA)
+            buffer.putShort(paramLength.toShort())
+            val checksum = calculateChecksum(buffer.array(), startIndex = 2, length = 1 + 1 + 2 + paramLength)
+            buffer.put(checksum)
+            buffer.putShort(FRAME_TRAILER)
+
+            return buffer.array()
+        }
+
+        private fun calculateChecksum(data: ByteArray, startIndex: Int, length: Int): Byte {
+            var checksum: Byte = 0
+            for (i in startIndex until startIndex + length) {
+                checksum = (checksum.toInt() xor data[i].toInt()).toByte()
+            }
+            return checksum
+        }
+    }
+
+
+    // 数据包结构（ESP32 → App）：镜像firmware里的typedefs.h
+
+    data class MuonData(
+        val cpuTime: Long,    // CPU时钟（8字节，lifetime counter）
+        val energy: Short,    // μ子能量（2字节，16位ADC测量值）
+        val pps: Int          // 上电以来PPS脉冲计数（4字节）
+    ) {
+        companion object {
+            const val SIZE = 14 
+            fun fromByteBuffer(buffer: ByteBuffer): MuonData {
+                require(buffer.order() == ByteOrder.LITTLE_ENDIAN) { "MuonData 解析需小端序" }
+                return MuonData(
+                    cpuTime = buffer.long,    // 读取8字节uint64_t
+                    energy = buffer.short,    // 读取2字节uint16_t
+                    pps = buffer.int          // 读取4字节uint32_t
+                )
+            }
+        }
+    }
+
+
+    data class MuonDataPkg(
+        val head: ByteArray,        // 包头部标识（3字节：0xAA,0xBB,0xCC）
+        val pkgCnt: Int,            // 全局数据包计数（4字节，掉电不丢失）
+        val utc: Int,               // 包第一个计数的UTC时间（4字节）
+        val muonDataList: List<MuonData>,  // 35个μ子事件（35×14=490字节）
+        val tail: ByteArray,        // 包尾部标识（3字节：0xDD,0xEE,0xFF）
+        val crc: Short,             // 校验和（2字节）
+        val reserved: ByteArray     // 预留字段（6字节）
+    ) {
+        companion object {
+            const val TOTAL_SIZE = 512 // 数据包总字节数（与固件一致）
+            private val HEAD_EXPECTED = byteArrayOf(0xAA, 0xBB, 0xCC) // 预期头部标识
+            private val TAIL_EXPECTED = byteArrayOf(0xDD, 0xEE, 0xFF) // 预期尾部标识
+
+            /**
+             * 从原始字节流解析 MuonDataPkg
+             * @param rawData ESP32发送的512字节原始数据
+             * @return 解析后的 MuonDataPkg 对象（解析失败抛出异常）
+             */
+            fun fromRawData(rawData: ByteArray): MuonDataPkg {
+                require(rawData.size == TOTAL_SIZE) {
+                    "μ子数据包长度错误：预期512字节，实际${rawData.size}字节"
+                }
+                val buffer = ByteBuffer.wrap(rawData)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+
+                val head = ByteArray(3).also { buffer.get(it) }
+                require(head.contentEquals(HEAD_EXPECTED)) {
+                    "μ子数据包头部标识错误：预期${HEAD_EXPECTED.contentToString()}，实际${head.contentToString()}"
+                }
+
+                val pkgCnt = buffer.int
+                val utc = buffer.int
+
+                val muonDataList = mutableListOf<MuonData>()
+                repeat(35) {
+                    muonDataList.add(MuonData.fromByteBuffer(buffer))
+                }
+
+                val tail = ByteArray(3).also { buffer.get(it) }
+                require(tail.contentEquals(TAIL_EXPECTED)) {
+                    "μ子数据包尾部标识错误：预期${TAIL_EXPECTED.contentToString()}，实际${tail.contentToString()}"
+                }
+
+                val crc = buffer.short
+                val calculatedCrc = Command.calculateChecksum(
+                    data = rawData,
+                    startIndex = 3, // 从PkgCnt开始到reserved结束（3+4+4+490+3+6=509字节）
+                    length = TOTAL_SIZE - 3 - 2 // 总长度 512字节- 头部3字节 - CRC2字节 = 507，需与esp32的CRC计算范围一致
+                )
+                require((crc.toInt() and 0xFFFF) == (calculatedCrc.toInt() and 0xFFFF)) {
+                    "μ子数据包CRC校验失败：预期${crc.toInt() and 0xFFFF}，实际${calculatedCrc.toInt() and 0xFFFF}"
+                }
+
+                val reserved = ByteArray(6).also { buffer.get(it) }
+
+                return MuonDataPkg(head, pkgCnt, utc, muonDataList, tail, crc, reserved)
+            }
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            other as MuonDataPkg
+            return head.contentEquals(other.head) &&
+                    pkgCnt == other.pkgCnt &&
+                    utc == other.utc &&
+                    muonDataList == other.muonDataList &&
+                    tail.contentEquals(other.tail) &&
+                    crc == other.crc &&
+                    reserved.contentEquals(other.reserved)
+        }
+
+        override fun hashCode(): Int {
+            var result = head.contentHashCode()
+            result = 31 * result + pkgCnt
+            result = 31 * result + utc
+            result = 31 * result + muonDataList.hashCode()
+            result = 31 * result + tail.contentHashCode()
+            result = 31 * result + crc
+            result = 31 * result + reserved.contentHashCode()
+            return result
+        }
+
+        override fun toString(): String {
+            return "MuonDataPkg(pkgCnt=$pkgCnt, utc=$utc, muonCount=${muonDataList.size}, " +
+                    "head=${head.contentToString()}, tail=${tail.contentToString()})"
+        }
+    }
+
+    data class TimeLineData(
+        val cpuTime: Long,    // 写入数据时的CPU时钟（8字节）
+        val pps: Int,         // 当前PPS脉冲计数（4字节）
+        val utc: Int,         // 最近一次UTC时间戳（4字节）
+        val ppsUtc: Int,      // 上次记录UTC时的PPS计数（4字节）
+        val cpuTimePps: Long, // 上次收到PPS脉冲时的CPU时钟（8字节）
+        val gpsLong: Int,     // GPS经度（4字节，1m级，0°-360°）
+        val gpsLat: Int,      // GPS纬度（4字节，1m级，-90°-90°）
+        val gpsAlt: Short,    // GPS海拔（2字节，1m级）
+        val accX: Byte,       // 加速度X轴（1字节）
+        val accY: Byte,       // 加速度Y轴（1字节）
+        val accZ: Byte,       // 加速度Z轴（1字节）
+        val siPMTmp: Short,   // SiPM附近温度（2字节，tmp112测量）
+        val mcUTmp: Byte,     // ESP32内置温度（1字节）
+        val siPMImon: Short,  // SiPM漏电流监测（2字节）
+        val siPMVmon: Short   // SiPM偏压监测（2字节）
+    ) {
+        companion object {
+            const val SIZE = 48 // 结构体总字节数（与固件一致）
+
+            fun fromByteBuffer(buffer: ByteBuffer): TimeLineData {
+                require(buffer.order() == ByteOrder.LITTLE_ENDIAN) { "TimeLineData 解析需小端序" }
+                return TimeLineData(
+                    cpuTime = buffer.long,
+                    pps = buffer.int,
+                    utc = buffer.int,
+                    ppsUtc = buffer.int,
+                    cpuTimePps = buffer.long,
+                    gpsLong = buffer.int,
+                    gpsLat = buffer.int,
+                    gpsAlt = buffer.short,
+                    accX = buffer.byte,
+                    accY = buffer.byte,
+                    accZ = buffer.byte,
+                    siPMTmp = buffer.short,
+                    mcUTmp = buffer.byte,
+                    siPMImon = buffer.short,
+                    siPMVmon = buffer.short
+                )
+            }
+        }
+    }
+
+    data class TimeLinePkg(
+        val head: ByteArray,            // 包头部标识（3字节：0x12,0x34,0x56）
+        val pkgCnt: Int,                // 全局数据包计数（4字节，掉电不丢失）
+        val timeLineDataList: List<TimeLineData>,  // 10个时间线事件（10×48=480字节）
+        val tail: ByteArray,            // 包尾部标识（3字节：0x78,0x9A,0xBC）
+        val crc: Short,                 // 校验和（2字节）
+        val reserve: ByteArray          // 预留字段（20字节）
+    ) {
+        companion object {
+            const val TOTAL_SIZE = 512 // 数据包总字节数（与固件一致）
+            private val HEAD_EXPECTED = byteArrayOf(0x12, 0x34, 0x56) // 预期头部标识
+            private val TAIL_EXPECTED = byteArrayOf(0x78, 0x9A, 0xBC) // 预期尾部标识
+
+            fun fromRawData(rawData: ByteArray): TimeLinePkg {
+                require(rawData.size == TOTAL_SIZE) {
+                    "时间线数据包长度错误：预期512字节，实际${rawData.size}字节"
+                }
+
+                val buffer = ByteBuffer.wrap(rawData)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+
+                val head = ByteArray(3).also { buffer.get(it) }
+                require(head.contentEquals(HEAD_EXPECTED)) {
+                    "时间线数据包头部标识错误：预期${HEAD_EXPECTED.contentToString()}，实际${head.contentToString()}"
+                }
+
+                val pkgCnt = buffer.int
+
+                val timeLineDataList = mutableListOf<TimeLineData>()
+                repeat(10) {
+                    timeLineDataList.add(TimeLineData.fromByteBuffer(buffer))
+                }
+
+                val tail = ByteArray(3).also { buffer.get(it) }
+                require(tail.contentEquals(TAIL_EXPECTED)) {
+                    "时间线数据包尾部标识错误：预期${TAIL_EXPECTED.contentToString()}，实际${tail.contentToString()}"
+                }
+
+                val crc = buffer.short
+                val calculatedCrc = Command.calculateChecksum(
+                    data = rawData,
+                    startIndex = 3, 
+                    length = TOTAL_SIZE - 3 - 2 // 总长度 - 头部3字节 - CRC2字节 = 507
+                )
+                require((crc.toInt() and 0xFFFF) == (calculatedCrc.toInt() and 0xFFFF)) {
+                    "时间线数据包CRC校验失败：预期${crc.toInt() and 0xFFFF}，实际${calculatedCrc.toInt() and 0xFFFF}"
+                }
+
+                val reserve = ByteArray(20).also { buffer.get(it) }
+
+                return TimeLinePkg(head, pkgCnt, timeLineDataList, tail, crc, reserve)
+            }
+        }
+
+        // 重写equals和hashCode
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            other as TimeLinePkg
+            return head.contentEquals(other.head) &&
+                    pkgCnt == other.pkgCnt &&
+                    timeLineDataList == other.timeLineDataList &&
+                    tail.contentEquals(other.tail) &&
+                    crc == other.crc &&
+                    reserve.contentEquals(other.reserve)
+        }
+
+        override fun hashCode(): Int {
+            var result = head.contentHashCode()
+            result = 31 * result + pkgCnt
+            result = 31 * result + timeLineDataList.hashCode()
+            result = 31 * result + tail.contentHashCode()
+            result = 31 * result + crc
+            result = 31 * result + reserve.contentHashCode()
+            return result
+        }
+
+        // 打印数据包信息
+        override fun toString(): String {
+            return "TimeLinePkg(pkgCnt=$pkgCnt, eventCount=${timeLineDataList.size}, " +
+                    "head=${head.contentToString()}, tail=${tail.contentToString()})"
+        }
+    }
+}


### PR DESCRIPTION
添加了一个protocol.kt实现请求指令帧和数据库格式定义，在main activity中发送指令，并在与ble相关的文件中增加了发送指令的命令

## Summary by Sourcery

定义应用程序与 ESP32 之间的协议，并从主界面接入一个基础的 BLE 命令触发器。

New Features:
- 引入一个 Protocol 模块，用于构建请求命令帧，并从 ESP32 字节流中解析固定大小的 muon 和 timeline 数据包。
- 在仓库中添加一个发送 BLE 命令的入口，并在主活动界面中暴露一个按钮，在已连接时发送请求帧。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define the app–ESP32 protocol and hook up a basic BLE command trigger from the main UI.

New Features:
- Introduce a Protocol module that builds request command frames and parses fixed-size muon and timeline data packets from ESP32 byte streams.
- Add a BLE command-sending entry point in the repository and expose a button in the main activity to send a request frame when connected.

</details>