### PR TITLE
ci: 添加Android CI和Release工作流

### DIFF
--- a/.github/actions/build-and-sign/action.yml
+++ b/.github/actions/build-and-sign/action.yml
@@ -56,8 +56,13 @@ runs:
       run: chmod +x ./gradlew
       shell: bash
 
-    - name: Build release APK
-      run: ./gradlew assembleRelease -PciBuild=true
+    - name: Build release APK with optimizations
+      run: |
+        ./gradlew assembleRelease \
+          -PciBuild=true \
+          --configuration-cache \
+          --build-cache \
+          --scan
       shell: bash
 
     - name: Find unsigned APK
@@ -81,6 +86,13 @@ runs:
         keyStorePassword: ${{ inputs.key-store-password }}
         keyPassword: ${{ inputs.key-password }}
         buildToolsVersion: ${{ env.BUILD_TOOLS }}
+
+    - name: Cleanup Gradle cache
+      if: always()
+      run: |
+        rm -rf ~/.gradle/caches/
+        echo "Cleaned up Gradle cache to save storage"
+      shell: bash
 
     - name: Set outputs
       run: |

--- a/.github/actions/build-and-sign/action.yml
+++ b/.github/actions/build-and-sign/action.yml
@@ -1,0 +1,120 @@
+name: "Build and sign APK"
+description: "Composite action to build release APK and optionally sign it with provided keystore."
+author: "Copilot"
+runs:
+  using: "composite"
+  steps:
+    - name: Extract compileSdk version
+      id: extract_sdk
+      shell: bash
+      run: |
+        set -euo pipefail
+        file=app/build.gradle.kts
+        if [ -f "$file" ]; then
+          # Extract number in release(N) or compileSdk N pattern
+          sdk=$(grep -E "compileSdk|release\(" "$file" | grep -Eo 'release\([0-9]+\)|compileSdk \{[^}]*version = release\([0-9]+\)' || true)
+          if [ -n "$sdk" ]; then
+            # Extract digits
+            num=$(echo "$sdk" | grep -Eo '[0-9]+' | head -n1)
+            echo "COMPILE_SDK=$num" >> $GITHUB_ENV
+            echo "COMPILE_SDK=$num" >> $GITHUB_OUTPUT
+          fi
+        fi
+
+    - name: Set up JDK
+      uses: actions/setup-java@v5
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: temurin
+        cache: gradle
+
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v2
+      with:
+        api-level: ${{ inputs.api-level }}
+
+    - name: Determine build-tools version
+      run: |
+        set -euo pipefail
+        # If build-tools-version input provided use it; otherwise derive from COMPILE_SDK
+        if [ -n "${{ inputs.build-tools-version }}" ]; then
+          echo "BUILD_TOOLS=${{ inputs.build-tools-version }}" >> $GITHUB_ENV
+        else
+          if [ -n "${COMPILE_SDK:-}" ]; then
+            echo "BUILD_TOOLS=${COMPILE_SDK}.0.0" >> $GITHUB_ENV
+          else
+            echo "BUILD_TOOLS=36.0.0" >> $GITHUB_ENV
+          fi
+        fi
+        echo "Build tools version set to: ${BUILD_TOOLS}"
+      shell: bash
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x ./gradlew
+
+    - name: Build release APK
+      run: ./gradlew assembleRelease -PciBuild=true
+
+    - name: Find unsigned APK
+      id: find_unsigned
+      run: |
+        set -euo pipefail
+        apk=$(ls -1t app/build/outputs/apk/release/*.apk 2>/dev/null | head -n1 || true)
+        if [ -n "$apk" ]; then
+          echo "unsignedFile=$apk" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Sign APK (optional)
+      id: sign
+      if: ${{ inputs.run-sign == 'true' }}
+      uses: ilharp/sign-android-release@v2
+      with:
+        releaseDir: app/build/outputs/apk/release
+        signingKey: ${{ inputs.signing-key }}
+        keyAlias: ${{ inputs.key-alias }}
+        keyStorePassword: ${{ inputs.key-store-password }}
+        keyPassword: ${{ inputs.key-password }}
+        buildToolsVersion: ${{ env.BUILD_TOOLS }}
+
+    - name: Set outputs
+      run: |
+        echo "signedFile=${{ steps.sign.outputs.signedFile || '' }}" >> $GITHUB_OUTPUT
+        echo "unsignedFile=${{ steps.find_unsigned.outputs.unsignedFile || '' }}" >> $GITHUB_OUTPUT
+
+inputs:
+  run-sign:
+    description: "Whether to sign the APK"
+    required: false
+    default: "false"
+  signing-key:
+    description: "Base64 encoded keystore"
+    required: false
+  key-alias:
+    description: "Keystore alias"
+    required: false
+  key-store-password:
+    description: "Keystore password"
+    required: false
+  key-password:
+    description: "Key password"
+    required: false
+  build-tools-version:
+    description: "Android build-tools version to use"
+    required: false
+    default: ""
+  api-level:
+    description: "Android SDK API level"
+    required: false
+    default: "33"
+  java-version:
+    description: "Java version to use"
+    required: false
+    default: "21"
+
+outputs:
+  signedFile:
+    description: "Path to the signed file"
+    value: ${{ steps.sign.outputs.signedFile }}
+  unsignedFile:
+    description: "Path to the unsigned file"
+    value: ${{ steps.find_unsigned.outputs.unsignedFile }}

--- a/.github/actions/build-and-sign/action.yml
+++ b/.github/actions/build-and-sign/action.yml
@@ -26,7 +26,7 @@ runs:
       with:
         java-version: ${{ inputs.java-version }}
         distribution: temurin
-        cache: gradle
+        cache: "gradle"
 
     - name: Set up Android SDK
       uses: android-actions/setup-android@v2
@@ -87,13 +87,6 @@ runs:
         keyPassword: ${{ inputs.key-password }}
         buildToolsVersion: ${{ env.BUILD_TOOLS }}
 
-    - name: Cleanup Gradle cache
-      if: always()
-      run: |
-        rm -rf ~/.gradle/caches/
-        echo "Cleaned up Gradle cache to save storage"
-      shell: bash
-
     - name: Set outputs
       run: |
         echo "signedFile=${{ steps.sign.outputs.signedFile || '' }}" >> $GITHUB_OUTPUT
@@ -102,7 +95,7 @@ runs:
 
 inputs:
   run-sign:
-    description: "Whether to sign the APK"
+    description: "Whether to sign APK"
     required: false
     default: "false"
   signing-key:
@@ -132,8 +125,8 @@ inputs:
 
 outputs:
   signedFile:
-    description: "Path to the signed file"
+    description: "Path to signed file"
     value: ${{ steps.sign.outputs.signedFile }}
   unsignedFile:
-    description: "Path to the unsigned file"
+    description: "Path to unsigned file"
     value: ${{ steps.find_unsigned.outputs.unsignedFile }}

--- a/.github/actions/build-and-sign/action.yml
+++ b/.github/actions/build-and-sign/action.yml
@@ -4,21 +4,31 @@ author: "Copilot"
 runs:
   using: "composite"
   steps:
-    - name: Extract compileSdk version
+    - name: Determine compileSdk version
       id: extract_sdk
       shell: bash
       run: |
         set -euo pipefail
+        # Prefer explicit input over auto-detection
+        if [ -n "${{ inputs.compile-sdk }}" ]; then
+          echo "COMPILE_SDK=${{ inputs.compile-sdk }}" >> $GITHUB_ENV
+          echo "COMPILE_SDK=${{ inputs.compile-sdk }}" >> $GITHUB_OUTPUT
+          echo "Using explicit compile-sdk input: ${{ inputs.compile-sdk }}"
+          exit 0
+        fi
+        # Fallback: extract from build.gradle.kts
         file=app/build.gradle.kts
         if [ -f "$file" ]; then
-          # Extract number in release(N) or compileSdk N pattern
-          sdk=$(grep -E "compileSdk|release\(" "$file" | grep -Eo 'release\([0-9]+\)|compileSdk \{[^}]*version = release\([0-9]+\)' || true)
-          if [ -n "$sdk" ]; then
-            # Extract digits
-            num=$(echo "$sdk" | grep -Eo '[0-9]+' | head -n1)
+          num=$(grep -Eo 'compileSdk.*?[0-9]+|release\([0-9]+\)' "$file" | grep -Eo '[0-9]+' | head -n1 || true)
+          if [ -n "$num" ]; then
             echo "COMPILE_SDK=$num" >> $GITHUB_ENV
             echo "COMPILE_SDK=$num" >> $GITHUB_OUTPUT
+            echo "Auto-detected compileSdk: $num"
+          else
+            echo "::warning::Could not auto-detect compileSdk from $file"
           fi
+        else
+          echo "::warning::$file not found, skipping compileSdk detection"
         fi
 
     - name: Set up JDK
@@ -104,7 +114,11 @@ inputs:
     description: "Key password"
     required: false
   build-tools-version:
-    description: "Android build-tools version to use"
+    description: "Android build-tools version to use (overrides auto-detection)"
+    required: false
+    default: ""
+  compile-sdk:
+    description: "compileSdk version (overrides auto-detection from build.gradle.kts)"
     required: false
     default: ""
   api-level:

--- a/.github/actions/build-and-sign/action.yml
+++ b/.github/actions/build-and-sign/action.yml
@@ -51,9 +51,11 @@ runs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x ./gradlew
+      shell: bash
 
     - name: Build release APK
       run: ./gradlew assembleRelease -PciBuild=true
+      shell: bash
 
     - name: Find unsigned APK
       id: find_unsigned
@@ -63,6 +65,7 @@ runs:
         if [ -n "$apk" ]; then
           echo "unsignedFile=$apk" >> $GITHUB_OUTPUT
         fi
+      shell: bash
 
     - name: Sign APK (optional)
       id: sign
@@ -80,6 +83,7 @@ runs:
       run: |
         echo "signedFile=${{ steps.sign.outputs.signedFile || '' }}" >> $GITHUB_OUTPUT
         echo "unsignedFile=${{ steps.find_unsigned.outputs.unsignedFile || '' }}" >> $GITHUB_OUTPUT
+      shell: bash
 
 inputs:
   run-sign:

--- a/.github/actions/build-and-sign/action.yml
+++ b/.github/actions/build-and-sign/action.yml
@@ -38,12 +38,15 @@ runs:
         set -euo pipefail
         # If build-tools-version input provided use it; otherwise derive from COMPILE_SDK
         if [ -n "${{ inputs.build-tools-version }}" ]; then
-          echo "BUILD_TOOLS=${{ inputs.build-tools-version }}" >> $GITHUB_ENV
+          export BUILD_TOOLS="${{ inputs.build-tools-version }}"
+          echo "BUILD_TOOLS=$BUILD_TOOLS" >> $GITHUB_ENV
         else
           if [ -n "${COMPILE_SDK:-}" ]; then
-            echo "BUILD_TOOLS=${COMPILE_SDK}.0.0" >> $GITHUB_ENV
+            export BUILD_TOOLS="${COMPILE_SDK}.0.0"
+            echo "BUILD_TOOLS=$BUILD_TOOLS" >> $GITHUB_ENV
           else
-            echo "BUILD_TOOLS=36.0.0" >> $GITHUB_ENV
+            export BUILD_TOOLS="36.0.0"
+            echo "BUILD_TOOLS=$BUILD_TOOLS" >> $GITHUB_ENV
           fi
         fi
         echo "Build tools version set to: ${BUILD_TOOLS}"

--- a/.github/actions/build-and-sign/action.yml
+++ b/.github/actions/build-and-sign/action.yml
@@ -59,10 +59,8 @@ runs:
     - name: Build release APK with optimizations
       run: |
         ./gradlew assembleRelease \
-          -PciBuild=true \
           --configuration-cache \
-          --build-cache \
-          --scan
+          --build-cache
       shell: bash
 
     - name: Find unsigned APK
@@ -87,11 +85,6 @@ runs:
         keyPassword: ${{ inputs.key-password }}
         buildToolsVersion: ${{ env.BUILD_TOOLS }}
 
-    - name: Set outputs
-      run: |
-        echo "signedFile=${{ steps.sign.outputs.signedFile || '' }}" >> $GITHUB_OUTPUT
-        echo "unsignedFile=${{ steps.find_unsigned.outputs.unsignedFile || '' }}" >> $GITHUB_OUTPUT
-      shell: bash
 
 inputs:
   run-sign:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,7 +1,27 @@
+# Android CI workflow
+#
+# This workflow builds a release APK, optionally signs it (when run manually or on a tag
+# and required secrets are configured), uploads the signed APK as an artifact, and
+# creates a GitHub Release when a tag is pushed.
+#
+# Required secrets (set in repository Settings > Secrets):
+# - ANDROID_SIGNING_KEY: base64-encoded keystore content
+# - ANDROID_KEY_ALIAS: alias within the keystore
+# - ANDROID_KEYSTORE_PASSWORD: keystore password
+# - ANDROID_KEY_PASSWORD: key password
+# GITHUB_TOKEN is provided automatically by GitHub Actions for release creation.
+
 name: Android CI
 
 on:
   push:
+    branches: [dev, main]
+    tags:
+      - "v*"
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,6 +30,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
@@ -20,7 +42,38 @@ jobs:
           distribution: "temurin"
           cache: gradle
 
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v2
+        with:
+          api-level: 33
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Build with Gradle
-        run: ./gradlew build
+
+      - name: Build release APK
+        run: ./gradlew assembleRelease -PciBuild=true
+
+      - name: Sign app APK
+        id: sign_app
+        if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') }}
+        uses: ilharp/sign-android-release@v2
+        with:
+          releaseDir: app/build/outputs/apk/release
+          signingKey: ${{ secrets.ANDROID_SIGNING_KEY }}
+          keyAlias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          buildToolsVersion: 36.0.0
+
+      - name: Upload signed APK as artifact
+        if: ${{ steps.sign_app.outputs.signedFile != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: signed-apk
+          path: ${{ steps.sign_app.outputs.signedFile }}
+
+      - name: Upload unsigned APK as artifact (fallback)
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-apk
+          path: app/build/outputs/apk/release/*.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,11 +30,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
 
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.caching=true"
+
     steps:
-      - uses: actions/checkout@v6
       - name: Build and (optionally) sign APK
         id: build_sign
         uses: ./.github/actions/build-and-sign

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,6 +38,11 @@ jobs:
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.caching=true"
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Build and (optionally) sign APK
         id: build_sign
         uses: ./.github/actions/build-and-sign

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,8 +19,8 @@ on:
     tags:
       - "v*"
   pull_request:
-    types: [closed]
-    branches: [main]
+    types: [opened, synchronize, reopened]
+    branches: [dev, main]
   workflow_dispatch: {}
 
 concurrency:
@@ -35,45 +35,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: set up JDK 21
-        uses: actions/setup-java@v5
+      - name: Build and (optionally) sign APK
+        id: build_sign
+        uses: ./.github/actions/build-and-sign
         with:
-          java-version: "21"
-          distribution: "temurin"
-          cache: gradle
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v2
-        with:
-          api-level: 33
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Build release APK
-        run: ./gradlew assembleRelease -PciBuild=true
-
-      - name: Sign app APK
-        id: sign_app
-        if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') }}
-        uses: ilharp/sign-android-release@v2
-        with:
-          releaseDir: app/build/outputs/apk/release
-          signingKey: ${{ secrets.ANDROID_SIGNING_KEY }}
-          keyAlias: ${{ secrets.ANDROID_KEY_ALIAS }}
-          keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          buildToolsVersion: 36.0.0
+          run-sign: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') }}
+          signing-key: ${{ secrets.ANDROID_SIGNING_KEY }}
+          key-alias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          key-store-password: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          key-password: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          api-level: 36
 
       - name: Upload signed APK as artifact
-        if: ${{ steps.sign_app.outputs.signedFile != '' }}
+        if: ${{ steps.build_sign.outputs.signedFile != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: signed-apk
-          path: ${{ steps.sign_app.outputs.signedFile }}
+          path: ${{ steps.build_sign.outputs.signedFile }}
 
       - name: Upload unsigned APK as artifact (fallback)
+        if: ${{ steps.build_sign.outputs.signedFile == '' || steps.build_sign.outcome == 'skipped' || steps.build_sign.outcome == 'failure' }}
         uses: actions/upload-artifact@v4
         with:
           name: unsigned-apk
-          path: app/build/outputs/apk/release/*.apk
+          path: ${{ steps.build_sign.outputs.unsignedFile }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -47,7 +47,7 @@ jobs:
         id: build_sign
         uses: ./.github/actions/build-and-sign
         with:
-          run-sign: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') }}
+          run-sign: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
           signing-key: ${{ secrets.ANDROID_SIGNING_KEY }}
           key-alias: ${{ secrets.ANDROID_KEY_ALIAS }}
           key-store-password: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -62,7 +62,7 @@ jobs:
           path: ${{ steps.build_sign.outputs.signedFile }}
 
       - name: Upload unsigned APK as artifact (fallback)
-        if: ${{ steps.build_sign.outputs.signedFile == '' || steps.build_sign.outcome == 'skipped' || steps.build_sign.outcome == 'failure' }}
+        if: ${{ steps.build_sign.outputs.unsignedFile != '' && (steps.build_sign.outputs.signedFile == '' || steps.build_sign.outcome == 'skipped' || steps.build_sign.outcome == 'failure') }}
         uses: actions/upload-artifact@v4
         with:
           name: unsigned-apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,14 +102,14 @@ jobs:
             if [ "${{ github.event.pull_request.head.ref }}" != "dev" ]; then
               echo "PR not from dev; skipping release." && exit 1
             fi
-            PR_TITLE='${{ github.event.pull_request.title }}'
+            PR_TITLE="${{ github.event.pull_request.title }}"
             VERSION=$(echo "$PR_TITLE" | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' || true)
             if [ -z "$VERSION" ]; then
               echo "No version tag found in PR title: $PR_TITLE" && exit 1
             fi
           fi
           if [ -z "$VERSION" ] && [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION='${{ github.event.inputs.version }}'
+            VERSION="${{ github.event.inputs.version }}"
             if [ -z "$VERSION" ]; then
               echo "No version provided for workflow_dispatch; aborting." && exit 1
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,12 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag (vX.Y.Z) to use when manually running the workflow"
+        required: false
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -46,27 +51,32 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build release APK
-        run: ./gradlew assembleRelease -PciBuild=true
-
-      - name: Sign app APK
-        id: sign_app
-        if: >-
-          startsWith(github.ref, 'refs/tags/') ||
-          (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') ||
-          github.event_name == 'workflow_dispatch'
-        uses: ilharp/sign-android-release@v2
+      - name: Build and (optionally) sign APK
+        id: build_sign
+        uses: ./.github/actions/build-and-sign
         with:
-          releaseDir: app/build/outputs/apk/release
-          signingKey: ${{ secrets.ANDROID_SIGNING_KEY }}
-          keyAlias: ${{ secrets.ANDROID_KEY_ALIAS }}
-          keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          buildToolsVersion: 36.0.0
+          run-sign: ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') || github.event_name == 'workflow_dispatch' }}
+          signing-key: ${{ secrets.ANDROID_SIGNING_KEY }}
+          key-alias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          key-store-password: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          key-password: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          api-level: 36
 
       - name: Determine APK to release
         run: |
           set -euo pipefail
+          # Prefer signed file from build_sign if present
+          signed=${{ steps.build_sign.outputs.signedFile }}
+          unsigned=${{ steps.build_sign.outputs.unsignedFile }}
+          if [ -n "$signed" ]; then
+            echo "RELEASE_APK=$signed" >> $GITHUB_ENV
+            exit 0
+          fi
+          if [ -n "$unsigned" ]; then
+            echo "RELEASE_APK=$unsigned" >> $GITHUB_ENV
+            exit 0
+          fi
+          # fallback: pick latest file
           apk=$(ls -1t app/build/outputs/apk/release/*.apk 2>/dev/null | head -n 1 || true)
           if [ -z "$apk" ]; then
             echo "No APK found to upload" && exit 1
@@ -96,6 +106,12 @@ jobs:
             VERSION=$(echo "$PR_TITLE" | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' || true)
             if [ -z "$VERSION" ]; then
               echo "No version tag found in PR title: $PR_TITLE" && exit 1
+            fi
+          fi
+          if [ -z "$VERSION" ] && [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION='${{ github.event.inputs.version }}'
+            if [ -z "$VERSION" ]; then
+              echo "No version provided for workflow_dispatch; aborting." && exit 1
             fi
           fi
           if [ -z "$VERSION" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,145 @@
+# Release workflow
+# Triggers a release when:
+# - a tag v* is pushed (push tag)
+# - a pull request into main is closed and merged from dev
+# - manual dispatch
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v2
+        with:
+          api-level: 33
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build release APK
+        run: ./gradlew assembleRelease -PciBuild=true
+
+      - name: Sign app APK
+        id: sign_app
+        if: >-
+          startsWith(github.ref, 'refs/tags/') ||
+          (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') ||
+          github.event_name == 'workflow_dispatch'
+        uses: ilharp/sign-android-release@v2
+        with:
+          releaseDir: app/build/outputs/apk/release
+          signingKey: ${{ secrets.ANDROID_SIGNING_KEY }}
+          keyAlias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          buildToolsVersion: 36.0.0
+
+      - name: Determine APK to release
+        run: |
+          set -euo pipefail
+          apk=$(ls -1t app/build/outputs/apk/release/*.apk 2>/dev/null | head -n 1 || true)
+          if [ -z "$apk" ]; then
+            echo "No APK found to upload" && exit 1
+          fi
+          echo "RELEASE_APK=$apk" >> $GITHUB_ENV
+
+      - name: Determine version/tag
+        id: determine_version
+        run: |
+          set -euo pipefail
+          VERSION=""
+          if [ "${{ github.event_name }}" = "push" ]; then
+            if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+              VERSION=${GITHUB_REF#refs/tags/}
+            fi
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ github.event.pull_request.merged }}" != "true" ]; then
+              echo "PR not merged; aborting release." && exit 1
+            fi
+            if [ "${{ github.event.pull_request.base.ref }}" != "main" ]; then
+              echo "PR not targeting main; skipping release." && exit 1
+            fi
+            if [ "${{ github.event.pull_request.head.ref }}" != "dev" ]; then
+              echo "PR not from dev; skipping release." && exit 1
+            fi
+            PR_TITLE='${{ github.event.pull_request.title }}'
+            VERSION=$(echo "$PR_TITLE" | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' || true)
+            if [ -z "$VERSION" ]; then
+              echo "No version tag found in PR title: $PR_TITLE" && exit 1
+            fi
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "No version determined from event; aborting." && exit 1
+          fi
+          echo "RELEASE_TAG=$VERSION" >> $GITHUB_ENV
+
+      - name: Create tag if missing (PR merge)
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          COMMIT=${{ github.event.pull_request.merge_commit_sha }}
+          if [ -z "$COMMIT" ] || [ "$COMMIT" = "null" ]; then
+            COMMIT=${GITHUB_SHA}
+          fi
+          if ! git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            git tag -a "$RELEASE_TAG" "$COMMIT" -m "Release $RELEASE_TAG"
+            git push origin "$RELEASE_TAG"
+          else
+            echo "Tag $RELEASE_TAG already exists; skipping tag creation."
+          fi
+
+      - name: Generate changelog
+        id: generate_changelog
+        run: |
+          set -euo pipefail
+          TAG=${{ env.RELEASE_TAG }}
+          git fetch --prune --unshallow --tags || true
+          PREV_TAG=$(git tag --sort=-v:refname | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+' | grep -v "^$TAG$" | head -n1 || true)
+          if [ -n "$PREV_TAG" ]; then
+            git log $PREV_TAG..HEAD --pretty=format:"- %s (%an)" > CHANGELOG.md
+          else
+            git log --pretty=format:"- %s (%an)" > CHANGELOG.md
+          fi
+          echo "Generated changelog:" && echo "-----" && cat CHANGELOG.md && echo "-----"
+
+      - name: Create GitHub Release and upload APK
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ env.RELEASE_TAG }}
+          bodyFile: CHANGELOG.md
+          artifacts: ${{ env.RELEASE_APK }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,17 +96,21 @@ jobs:
             if [ -z "$VERSION" ]; then
               echo "No version tag found in PR title: $PR_TITLE" && exit 1
             fi
-          fi
-          if [ -z "$VERSION" ] && [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ github.event.inputs.version }}"
             if [ -z "$VERSION" ]; then
-              echo "No version provided for workflow_dispatch; aborting." && exit 1
+              echo "No version provided for workflow_dispatch; aborting." >&2 && exit 1
+            fi
+            # Enforce vX.Y.Z format to avoid creating malformed tags
+            if ! echo "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "Invalid version format: '$VERSION'. Expected vX.Y.Z (e.g., v1.2.3)." >&2 && exit 1
             fi
           fi
           if [ -z "$VERSION" ]; then
             echo "No version determined from event; aborting." && exit 1
           fi
           echo "RELEASE_TAG=$VERSION" >> $GITHUB_ENV
+
 
       - name: Create tag if missing (PR merge)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,29 +27,18 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.merged == true
+    timeout-minutes: 30
     permissions:
       contents: write
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v5
-        with:
-          java-version: "21"
-          distribution: "temurin"
-          cache: gradle
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v2
-        with:
-          api-level: 33
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
 
       - name: Build and (optionally) sign APK
         id: build_sign
@@ -66,8 +55,8 @@ jobs:
         run: |
           set -euo pipefail
           # Prefer signed file from build_sign if present
-          signed=${{ steps.build_sign.outputs.signedFile }}
-          unsigned=${{ steps.build_sign.outputs.unsignedFile }}
+          signed="${{ steps.build_sign.outputs.signedFile }}"
+          unsigned="${{ steps.build_sign.outputs.unsignedFile }}"
           if [ -n "$signed" ]; then
             echo "RELEASE_APK=$signed" >> $GITHUB_ENV
             exit 0
@@ -126,9 +115,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          COMMIT=${{ github.event.pull_request.merge_commit_sha }}
+          COMMIT="${{ github.event.pull_request.merge_commit_sha }}"
           if [ -z "$COMMIT" ] || [ "$COMMIT" = "null" ]; then
-            COMMIT=${GITHUB_SHA}
+            COMMIT="${GITHUB_SHA}"
           fi
           if ! git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
             git tag -a "$RELEASE_TAG" "$COMMIT" -m "Release $RELEASE_TAG"
@@ -141,11 +130,11 @@ jobs:
         id: generate_changelog
         run: |
           set -euo pipefail
-          TAG=${{ env.RELEASE_TAG }}
+          TAG="${{ env.RELEASE_TAG }}"
           git fetch --prune --unshallow --tags || true
-          PREV_TAG=$(git tag --sort=-v:refname | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+' | grep -v "^$TAG$" | head -n1 || true)
+          PREV_TAG=$(git tag --sort=-v:refname | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+' | grep -v "^${TAG}$" | head -n1 || true)
           if [ -n "$PREV_TAG" ]; then
-            git log $PREV_TAG..HEAD --pretty=format:"- %s (%an)" > CHANGELOG.md
+            git log "${PREV_TAG}..${TAG}" --pretty=format:"- %s (%an)" > CHANGELOG.md
           else
             git log --pretty=format:"- %s (%an)" > CHANGELOG.md
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ uv.lock
 *.salive
 .venv/
 .kotlin/
+/key


### PR DESCRIPTION
## Summary by Sourcery

添加自动化的 Android 发布构建，并通过标签、PR 合并和手动触发与 GitHub Releases 集成。

增强功能：
- 创建可复用的复合 GitHub Action，用于构建优化的发布 APK，并可选地使用可配置的 Android SDK 和 build-tools 设置进行签名。

CI：
- 扩展 Android CI 工作流，在 main/dev 分支、标签、拉取请求以及手动运行时构建发布 APK，并上传已签名和未签名的构件。

部署：
- 引入专门的 Release 工作流，用于构建/签名 APK，根据事件或输入生成版本标签，生成变更日志，并发布附带 APK 的 GitHub Releases。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automated Android release builds and GitHub Releases integration driven by tags, PR merges, and manual triggers.

Enhancements:
- Create a reusable composite GitHub Action to build optimized release APKs and optionally sign them using configurable Android SDK and build-tools settings.

CI:
- Expand Android CI workflow to build release APKs on main/dev branches, tags, pull requests, and manual runs, uploading signed and unsigned artifacts.

Deployment:
- Introduce a dedicated Release workflow that builds/signs APKs, derives version tags from events or input, generates a changelog, and publishes GitHub Releases with attached APKs.

</details>

CI：
- 扩展 Android CI 工作流，使其在 main/dev 分支、标签、Pull Request 和手动触发时运行，构建发布版 APK，并上传已签名/未签名的构件（artifacts）。
- 引入专用的 Release 工作流，用于构建/签名 APK，从标签、PR 标题或手动输入中派生版本标签，生成变更日志（changelog），并在 GitHub Releases 中发布附带 APK 的版本。
- 创建可复用的复合 GitHub Action，用于通过 Gradle 构建发布版 APK，并可选地使用可配置的 Android SDK 和 build-tools 设置对其进行签名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加自动化的 Android 发布构建，并通过标签、PR 合并和手动触发与 GitHub Releases 集成。

增强功能：
- 创建可复用的复合 GitHub Action，用于构建优化的发布 APK，并可选地使用可配置的 Android SDK 和 build-tools 设置进行签名。

CI：
- 扩展 Android CI 工作流，在 main/dev 分支、标签、拉取请求以及手动运行时构建发布 APK，并上传已签名和未签名的构件。

部署：
- 引入专门的 Release 工作流，用于构建/签名 APK，根据事件或输入生成版本标签，生成变更日志，并发布附带 APK 的 GitHub Releases。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automated Android release builds and GitHub Releases integration driven by tags, PR merges, and manual triggers.

Enhancements:
- Create a reusable composite GitHub Action to build optimized release APKs and optionally sign them using configurable Android SDK and build-tools settings.

CI:
- Expand Android CI workflow to build release APKs on main/dev branches, tags, pull requests, and manual runs, uploading signed and unsigned artifacts.

Deployment:
- Introduce a dedicated Release workflow that builds/signs APKs, derives version tags from events or input, generates a changelog, and publishes GitHub Releases with attached APKs.

</details>

</details>