### PR TITLE
fix: 加密存储 token 并脱敏网络日志

### DIFF
--- a/.github/actions/build-and-sign/action.yml
+++ b/.github/actions/build-and-sign/action.yml
@@ -31,18 +31,6 @@ runs:
           echo "::warning::$file not found, skipping compileSdk detection"
         fi
 
-    - name: Set up JDK
-      uses: actions/setup-java@v5
-      with:
-        java-version: ${{ inputs.java-version }}
-        distribution: temurin
-        cache: "gradle"
-
-    - name: Set up Android SDK
-      uses: android-actions/setup-android@v2
-      with:
-        api-level: ${{ inputs.api-level }}
-
     - name: Determine build-tools version
       run: |
         set -euo pipefail
@@ -61,6 +49,24 @@ runs:
         fi
         echo "Build tools version set to: ${BUILD_TOOLS}"
       shell: bash
+
+    - name: Set up JDK
+      uses: actions/setup-java@v5
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: temurin
+        cache: "gradle"
+
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v3
+      with:
+        accept-android-sdk-licenses: true
+        log-accepted-android-sdk-licenses: false
+        packages: |
+          tools
+          platform-tools
+          platforms;android-${{ inputs.api-level }}
+          build-tools;${{ env.BUILD_TOOLS }}
 
     - name: Grant execute permission for gradlew
       run: chmod +x ./gradlew

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,8 @@ dependencies {
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.okio)
   implementation(libs.androidx.datastore.preferences)
+  implementation(libs.androidx.security.crypto)
+  implementation(libs.errorprone.annotations)
   implementation(libs.ktor.client.android)
   implementation("io.ktor:ktor-client-okhttp:${libs.versions.ktor.get()}")
   implementation("io.ktor:ktor-client-core:${libs.versions.ktor.get()}")

--- a/app/src/main/java/com/grid/cosrayapp/core/datastore/EncryptedTokenStore.kt
+++ b/app/src/main/java/com/grid/cosrayapp/core/datastore/EncryptedTokenStore.kt
@@ -1,0 +1,50 @@
+package com.grid.cosrayapp.core.datastore
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+/**
+ * 用于存储 access/refresh token 的加密存储。
+ *
+ * 说明：
+ * - Token 属于高敏感信息，必须避免明文落盘。
+ * - 这里使用 AndroidX Security Crypto 基于 Keystore 的 AES256-GCM 加密。
+ */
+class EncryptedTokenStore(context: Context) {
+  private val masterKey: MasterKey =
+    MasterKey.Builder(context)
+      .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+      .build()
+
+  private val prefs =
+    EncryptedSharedPreferences.create(
+      context,
+      FILE_NAME,
+      masterKey,
+      EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+      EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+
+  fun readAccessToken(): String? = prefs.getString(KEY_ACCESS_TOKEN, null)
+
+  fun readRefreshToken(): String? = prefs.getString(KEY_REFRESH_TOKEN, null)
+
+  fun writeTokens(accessToken: String, refreshToken: String) {
+    prefs
+      .edit()
+      .putString(KEY_ACCESS_TOKEN, accessToken)
+      .putString(KEY_REFRESH_TOKEN, refreshToken)
+      .apply()
+  }
+
+  fun clear() {
+    prefs.edit().clear().apply()
+  }
+
+  private companion object {
+    private const val FILE_NAME = "cosray_secure_tokens"
+    private const val KEY_ACCESS_TOKEN = "access_token"
+    private const val KEY_REFRESH_TOKEN = "refresh_token"
+  }
+}

--- a/app/src/main/java/com/grid/cosrayapp/core/datastore/UserPreferencesDataSource.kt
+++ b/app/src/main/java/com/grid/cosrayapp/core/datastore/UserPreferencesDataSource.kt
@@ -3,6 +3,7 @@ package com.grid.cosrayapp.core.datastore
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -11,6 +12,8 @@ import com.grid.cosrayapp.domain.model.AuthTokens
 import com.grid.cosrayapp.domain.model.User
 import com.grid.cosrayapp.domain.model.UserId
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
 private const val USER_PREFERENCES_NAME = "cosray_user_preferences"
@@ -20,45 +23,55 @@ private val Context.dataStore: DataStore<Preferences> by
 
 class UserPreferencesDataSource(context: Context) : AuthPreferences {
   private val store: DataStore<Preferences> = context.dataStore
+  private val secureTokens = EncryptedTokenStore(context)
 
   @Suppress("ComplexCondition")
   override val authData: Flow<StoredAuthData?> =
-    store.data.map { preferences ->
-      val access = preferences[Keys.ACCESS_TOKEN]
-      val refresh = preferences[Keys.REFRESH_TOKEN]
-      val expires = preferences[Keys.EXPIRES_AT]
-      val userId = preferences[Keys.USER_ID]
-      val email = preferences[Keys.USER_EMAIL]
-      val name = preferences[Keys.USER_NAME]
-      if (
-        access != null &&
-          refresh != null &&
-          expires != null &&
-          userId != null &&
-          email != null &&
-          name != null
-      ) {
-        StoredAuthData(
-          user =
-            User(
-              id = UserId(userId),
-              email = email,
-              displayName = name,
-              avatarUrl = preferences[Keys.USER_AVATAR],
-              organization = preferences[Keys.USER_ORGANIZATION],
-              roles =
-                preferences[Keys.USER_ROLES]?.split(',')?.filter { it.isNotBlank() } ?: emptyList(),
-            ),
-          tokens =
-            AuthTokens.fromEpochMillis(
-              accessToken = access,
-              refreshToken = refresh,
-              expiresAtMillis = expires,
-            ),
-        )
-      } else {
-        null
-      }
+    flow {
+      migrateLegacyTokensIfNeeded()
+      emitAll(
+        store.data.map { preferences ->
+          // token 必须从加密存储读取；若发现旧的明文 token，则尝试迁移。
+          val legacyAccess = preferences[Keys.ACCESS_TOKEN]
+          val legacyRefresh = preferences[Keys.REFRESH_TOKEN]
+          val access = secureTokens.readAccessToken() ?: legacyAccess
+          val refresh = secureTokens.readRefreshToken() ?: legacyRefresh
+          val expires = preferences[Keys.EXPIRES_AT]
+          val userId = preferences[Keys.USER_ID]
+          val email = preferences[Keys.USER_EMAIL]
+          val name = preferences[Keys.USER_NAME]
+          if (
+            access != null &&
+              refresh != null &&
+              expires != null &&
+              userId != null &&
+              email != null &&
+              name != null
+          ) {
+            StoredAuthData(
+              user =
+                User(
+                  id = UserId(userId),
+                  email = email,
+                  displayName = name,
+                  avatarUrl = preferences[Keys.USER_AVATAR],
+                  organization = preferences[Keys.USER_ORGANIZATION],
+                  roles =
+                    preferences[Keys.USER_ROLES]?.split(',')?.filter { it.isNotBlank() }
+                      ?: emptyList(),
+                ),
+              tokens =
+                AuthTokens.fromEpochMillis(
+                  accessToken = access,
+                  refreshToken = refresh,
+                  expiresAtMillis = expires,
+                ),
+            )
+          } else {
+            null
+          }
+        }
+      )
     }
 
   val darkTheme: Flow<Boolean?> = store.data.map { preferences -> preferences[Keys.DARK_THEME] }
@@ -74,8 +87,9 @@ class UserPreferencesDataSource(context: Context) : AuthPreferences {
 
   override suspend fun persistAuth(user: User, tokens: AuthTokens) {
     store.edit { preferences ->
-      preferences[Keys.ACCESS_TOKEN] = tokens.accessToken
-      preferences[Keys.REFRESH_TOKEN] = tokens.refreshToken
+      // token 不落盘到 DataStore；仅保留与用户相关的非敏感信息与过期时间。
+      preferences.remove(Keys.ACCESS_TOKEN)
+      preferences.remove(Keys.REFRESH_TOKEN)
       preferences[Keys.EXPIRES_AT] = tokens.expiresAt.toEpochMilli()
       preferences[Keys.USER_ID] = user.id.value
       preferences[Keys.USER_EMAIL] = user.email
@@ -90,10 +104,55 @@ class UserPreferencesDataSource(context: Context) : AuthPreferences {
         preferences.remove(Keys.USER_ROLES)
       }
     }
+
+    // 单独写入加密存储。
+    secureTokens.writeTokens(tokens.accessToken, tokens.refreshToken)
   }
 
   override suspend fun clear() {
     store.edit { preferences -> preferences.clear() }
+    secureTokens.clear()
+  }
+
+  /**
+   * 将旧版本明文存储的 token 迁移到加密存储。
+   *
+   * 迁移失败策略：清空 token（强制重新登录），避免进入不一致状态。
+   */
+  private suspend fun migrateLegacyTokensIfNeeded() {
+    var legacyAccess: String? = null
+    var legacyRefresh: String? = null
+
+    store.edit { preferences ->
+      legacyAccess = preferences[Keys.ACCESS_TOKEN]
+      legacyRefresh = preferences[Keys.REFRESH_TOKEN]
+    }
+
+    if (legacyAccess == null) return
+
+    val existingSecureAccess = secureTokens.readAccessToken()
+    if (existingSecureAccess != null) {
+      store.edit { preferences ->
+        preferences.remove(Keys.ACCESS_TOKEN)
+        preferences.remove(Keys.REFRESH_TOKEN)
+      }
+      return
+    }
+
+    if (legacyRefresh == null) {
+      secureTokens.clear()
+    } else {
+      try {
+        secureTokens.writeTokens(legacyAccess!!, legacyRefresh!!)
+      } catch (_: Throwable) {
+        secureTokens.clear()
+      }
+    }
+
+    store.edit { preferences ->
+      preferences.remove(Keys.ACCESS_TOKEN)
+      preferences.remove(Keys.REFRESH_TOKEN)
+    }
   }
 
   private object Keys {
@@ -106,8 +165,8 @@ class UserPreferencesDataSource(context: Context) : AuthPreferences {
     val USER_AVATAR = stringPreferencesKey("user_avatar")
     val USER_ORGANIZATION = stringPreferencesKey("user_org")
     val USER_ROLES = stringPreferencesKey("user_roles")
-    val DARK_THEME = androidx.datastore.preferences.core.booleanPreferencesKey("dark_theme")
-    val OLED_DARK = androidx.datastore.preferences.core.booleanPreferencesKey("oled_dark")
+    val DARK_THEME = booleanPreferencesKey("dark_theme")
+    val OLED_DARK = booleanPreferencesKey("oled_dark")
   }
 }
 

--- a/app/src/main/java/com/grid/cosrayapp/core/network/HttpClientFactory.kt
+++ b/app/src/main/java/com/grid/cosrayapp/core/network/HttpClientFactory.kt
@@ -23,6 +23,40 @@ object HttpClientFactory {
   private const val SOCKET_TIMEOUT_MS = 30_000L
   private const val MAX_RETRIES = 3
 
+  /**
+   * 网络日志脱敏规则（任何构建类型都生效）。
+   *
+   * 原则：永不在日志中输出 token 明文（包括 Authorization: Bearer ...）。
+   */
+  internal fun redactNetworkLog(message: String): String {
+    // Header: Authorization: Bearer <token>
+    val authorizationHeaderRegex = Regex("(?i)(Authorization:)(\\s*)(Bearer\\s+)?([^\\r\\n]+)")
+    // JSON: "access": "..." / "refresh": "..." / "access_token": "..." / "refresh_token": "..."
+    val tokenFieldRegex =
+      Regex(
+        "(?i)\"(access|refresh|access_token|refresh_token)\"\\s*:\\s*\"[^\"]*\""
+      )
+
+    return message
+      .replace(authorizationHeaderRegex) { match ->
+        val headerName = match.groupValues[1]
+        "$headerName: [REDACTED]"
+      }
+      .replace(tokenFieldRegex) { match ->
+        // 保留字段名，仅替换值
+        val key = match.value.substringBefore(':')
+        "$key: \"[REDACTED]\""
+      }
+  }
+
+  private fun debugLogger(): Logger =
+    object : Logger {
+      override fun log(message: String) {
+        if (!BuildConfig.DEBUG) return
+        Log.d(TAG, redactNetworkLog(message))
+      }
+    }
+
   fun create(): HttpClient =
     if (shouldEnablePinning()) {
       HttpClient(OkHttp) {
@@ -51,14 +85,7 @@ object HttpClientFactory {
         }
 
         install(Logging) {
-          logger =
-            object : Logger {
-              override fun log(message: String) {
-                if (BuildConfig.DEBUG) {
-                  Log.d(TAG, message)
-                }
-              }
-            }
+          logger = debugLogger()
           level = if (BuildConfig.DEBUG) LogLevel.INFO else LogLevel.NONE
         }
 
@@ -94,14 +121,8 @@ object HttpClientFactory {
       }
 
       install(Logging) {
-        logger =
-          object : Logger {
-            override fun log(message: String) {
-              if (BuildConfig.DEBUG) {
-                Log.d(TAG, message)
-      }
-    }
-          }
+        // DEBUG 下也不输出 header/body（只保留基本可观测性），并额外兜底脱敏。
+        logger = debugLogger()
         level = if (BuildConfig.DEBUG) LogLevel.INFO else LogLevel.NONE
       }
 
@@ -137,14 +158,7 @@ object HttpClientFactory {
       }
 
       install(Logging) {
-        logger =
-          object : Logger {
-            override fun log(message: String) {
-              if (BuildConfig.DEBUG) {
-                Log.d(TAG, message)
-              }
-            }
-          }
+        logger = debugLogger()
         level = if (BuildConfig.DEBUG) LogLevel.INFO else LogLevel.NONE
       }
 

--- a/app/src/test/java/com/grid/cosrayapp/core/network/HttpClientFactoryRedactionTest.kt
+++ b/app/src/test/java/com/grid/cosrayapp/core/network/HttpClientFactoryRedactionTest.kt
@@ -1,0 +1,26 @@
+package com.grid.cosrayapp.core.network
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HttpClientFactoryRedactionTest {
+  @Test
+  fun `redaction should remove Authorization bearer token`() {
+    val raw = "Authorization: Bearer abc.def.ghi"
+    val redacted = HttpClientFactory.redactNetworkLog(raw)
+    assertFalse(redacted.contains("abc.def.ghi"))
+    assertTrue(redacted.contains("[REDACTED]"))
+  }
+
+  @Test
+  fun `redaction should remove token fields in json`() {
+    val raw = """{"access":"a1","refresh":"r1","access_token":"a2","refresh_token":"r2"}"""
+    val redacted = HttpClientFactory.redactNetworkLog(raw)
+    assertFalse(redacted.contains("\"a1\""))
+    assertFalse(redacted.contains("\"r1\""))
+    assertFalse(redacted.contains("\"a2\""))
+    assertFalse(redacted.contains("\"r2\""))
+    assertTrue(redacted.contains("[REDACTED]"))
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ navigationCommonKtx = "2.9.7"
 detekt = "2.0.0-alpha.2"
 ktfmtPlugin = "0.25.0"
 okio = "3.17.0"
+securityCrypto = "1.1.0-alpha06"
+errorProneAnnotations = "2.39.0"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
@@ -60,6 +62,8 @@ ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "k
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 androidx-navigation-common-ktx = { group = "androidx.navigation", name = "navigation-common-ktx", version.ref = "navigationCommonKtx" }
 okio = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
+errorprone-annotations = { group = "com.google.errorprone", name = "error_prone_annotations", version.ref = "errorProneAnnotations" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
fix #22 
fix #23 

## Summary by Sourcery

将认证令牌存储在基于加密 Keystore 的存储中，并确保网络日志永远不会暴露令牌值。

新功能：
- 引入 `EncryptedTokenStore`，使用 AndroidX Security Crypto 安全持久化访问令牌和刷新令牌。

缺陷修复：
- 防止以明文形式将令牌存储在 DataStore 中，以及防止令牌出现在 HTTP 日志输出中，包括 `Authorization` 请求头和与令牌相关的 JSON 字段。
- 添加从旧版明文令牌存储迁移到加密存储的路径，在迁移失败时清理不一致的数据。

改进：
- 优化 HTTP 客户端日志配置，在调试构建中仅记录请求头，并集中处理敏感信息脱敏逻辑。
- 简化深色主题设置相关的偏好键声明。

构建：
- 添加用于加密令牌存储的 AndroidX Security Crypto 依赖。

测试：
- 添加单元测试，验证网络日志脱敏会移除 JSON 负载中的 Bearer 令牌以及令牌字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Store authentication tokens in an encrypted keystore-backed store and ensure network logs never expose token values.

New Features:
- Introduce EncryptedTokenStore for securely persisting access and refresh tokens using AndroidX Security Crypto.

Bug Fixes:
- Prevent plaintext tokens from being stored in DataStore and from appearing in HTTP logging output, including Authorization headers and token-related JSON fields.
- Add a migration path from legacy plaintext token storage to encrypted storage, clearing inconsistent data on failure.

Enhancements:
- Refine HTTP client logging configuration to log only headers in debug builds with centralized redaction logic.
- Simplify preference key declarations for dark theme settings.

Build:
- Add AndroidX Security Crypto dependency for encrypted token storage.

Tests:
- Add unit tests verifying that network log redaction removes bearer tokens and token fields from JSON payloads.

</details>